### PR TITLE
Solved Overlapping Problem in List.html

### DIFF
--- a/CSS/list.css
+++ b/CSS/list.css
@@ -70,7 +70,7 @@ body {
 .Data {
     position: fixed;
     top: 20px;
-    right: 120px;
+    right: 20px;
     z-index: 1000;
 }
 
@@ -94,10 +94,11 @@ body {
 
 .Data1 {
     position: fixed;
-    top: 20px;
+    top: 70px;
     right: 20px;
     z-index: 1000;
 }
+
 
 .Data1 button {
     padding: 12px 20px;


### PR DESCRIPTION
There is an overlapping issue with the navigation buttons ("Daily Tasks" and "Study Tasks") in the Todo List application. Both buttons appear on top of each other, making them unreadable and difficult to interact with.

Steps to Reproduce
Open the Todo List app.

Observe the top navigation section.

Both "Daily Tasks" and "Study Tasks" buttons overlap in the UI.

Expected Behavior
Navigation buttons should be displayed clearly side by side, with no overlap, allowing users to access both options easily.
<img width="784" height="440" alt="Screenshot 2025-10-17 155202" src="https://github.com/user-attachments/assets/3a0042ca-85bf-4fd3-9355-26d6998d76cb" />
